### PR TITLE
채팅서버 DB 커넥션 변경으로 인한 도큐먼트 수정

### DIFF
--- a/src/main/java/com/windmeal/chat/domain/ChatroomDocument.java
+++ b/src/main/java/com/windmeal/chat/domain/ChatroomDocument.java
@@ -20,19 +20,6 @@ public class ChatroomDocument {
 
   private Long orderId;
 
-  private String ownerEmail;
-
-  private String guestEmail;
-
-  private String ownerNickname;
-
-  private String guestNickname;
-
-
-  private String ownerAlarmToken;
-
-  private String guestAlarmToken;
-
   private boolean isDeletedByOwner = false;
 
   private boolean isDeletedByGuest = false;
@@ -41,20 +28,12 @@ public class ChatroomDocument {
   private LocalDateTime createdTime;
 
   @Builder
-  public ChatroomDocument(Long ownerId, Long guestId, Long orderId, String ownerEmail,
-      String guestEmail, String ownerNickname, String guestNickname, String ownerAlarmToken,
-      String guestAlarmToken) {
+  public ChatroomDocument(Long ownerId, Long guestId, Long orderId) {
     this.ownerId = ownerId;
     this.guestId = guestId;
     this.orderId = orderId;
-    this.ownerEmail = ownerEmail;
-    this.guestEmail = guestEmail;
     this.isDeletedByOwner = false;
     this.isDeletedByGuest = false;
-    this.ownerNickname = ownerNickname;
-    this.guestNickname = guestNickname;
-    this.ownerAlarmToken = ownerAlarmToken;
-    this.guestAlarmToken = guestAlarmToken;
   }
 
 

--- a/src/main/java/com/windmeal/chat/dto/request/ChatRoomSaveRequest.java
+++ b/src/main/java/com/windmeal/chat/dto/request/ChatRoomSaveRequest.java
@@ -23,17 +23,11 @@ public class ChatRoomSaveRequest {
     }
 
 
-    public ChatroomDocument toDocument(Member owner, Member guest, Order order, String ownerAlarmToken, String guestAlarmToken) {
+    public ChatroomDocument toDocument(Member owner, Member guest, Order order) {
         return ChatroomDocument.builder()
             .ownerId(owner.getId())
             .guestId(guest.getId())
             .orderId(order.getId())
-            .ownerEmail(owner.getEmail())
-            .guestEmail(guest.getEmail())
-            .ownerAlarmToken(ownerAlarmToken)
-            .guestAlarmToken(guestAlarmToken)
-            .ownerNickname(owner.getNickname())
-            .guestNickname(guest.getNickname())
             .build();
     }
 }

--- a/src/main/java/com/windmeal/chat/service/ChatRoomService.java
+++ b/src/main/java/com/windmeal/chat/service/ChatRoomService.java
@@ -38,7 +38,7 @@ public class ChatRoomService {
   public ChatRoomResponse createChatRoom(ChatRoomSaveRequest requestDTO, Long currentMemberId) {
 
     Order order = orderRepository.findById(requestDTO.getOrderId())
-        .orElseThrow(() -> new OrderNotFoundException());
+        .orElseThrow(OrderNotFoundException::new);
     Member owner = memberRepository.findById(order.getOrderer_id())
         .orElseThrow(() -> new MemberNotFoundException("주문 작성자를 찾을 수 없습니다."));
     Member guest = memberRepository.findById(currentMemberId)
@@ -50,7 +50,7 @@ public class ChatRoomService {
       throw new OrderAlreadyMatchedException();
     }
     ChatroomDocument chatRoom = chatroomDocumentRepository.save(
-        requestDTO.toDocument(owner, guest, order, owner.getToken(), guest.getToken()));
+        requestDTO.toDocument(owner, guest, order));
     return ChatRoomResponse.of(chatRoom.getId(), chatRoom.getOwnerId(), chatRoom.getGuestId(),
         chatRoom.getOrderId(), owner.getToken());
   }

--- a/src/main/java/com/windmeal/member/domain/MemberBase.java
+++ b/src/main/java/com/windmeal/member/domain/MemberBase.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter


### PR DESCRIPTION
### PR 타입

- [x] 기능 수정

## 작업사항
- 채팅서버의 DB 커넥션 추가 (read only)로 인한 채팅 도큐먼트 필드 수정
     - 아이디만 포함하도록 변경
     - 기존의 닉네임, 이메일, 토큰 등의 필드 삭제
          - 트랜잭션의 불일치와 채팅서버의 코드가 깔끔해지지 못하는 문제 해결
