### PR TITLE
쿼리 수 감소를 위한 반정규화 필드 추가

### DIFF
--- a/src/main/java/com/windmeal/chat/domain/ChatroomDocument.java
+++ b/src/main/java/com/windmeal/chat/domain/ChatroomDocument.java
@@ -20,6 +20,10 @@ public class ChatroomDocument {
 
   private Long orderId;
 
+  private String ownerEmail;
+
+  private String guestEmail;
+
   private boolean isDeletedByOwner = false;
 
   private boolean isDeletedByGuest = false;
@@ -28,10 +32,13 @@ public class ChatroomDocument {
   private LocalDateTime createdTime;
 
   @Builder
-  public ChatroomDocument(Long ownerId, Long guestId, Long orderId) {
+  public ChatroomDocument(Long ownerId, Long guestId, Long orderId, String ownerEmail,
+      String guestEmail) {
     this.ownerId = ownerId;
     this.guestId = guestId;
     this.orderId = orderId;
+    this.ownerEmail = ownerEmail;
+    this.guestEmail = guestEmail;
     this.isDeletedByOwner = false;
     this.isDeletedByGuest = false;
   }

--- a/src/main/java/com/windmeal/chat/dto/request/ChatRoomSaveRequest.java
+++ b/src/main/java/com/windmeal/chat/dto/request/ChatRoomSaveRequest.java
@@ -28,6 +28,8 @@ public class ChatRoomSaveRequest {
             .ownerId(owner.getId())
             .guestId(guest.getId())
             .orderId(order.getId())
+            .ownerEmail(owner.getEmail())
+            .guestEmail(guest.getEmail())
             .build();
     }
 }


### PR DESCRIPTION
### PR 타입

- [x] 기능 수정

## 작업사항
- 쿼리 수 감소를 위해 필드 추가 (abc9113ed2dbad692e75b149e2d80300fdff320d)
     - 서비스의 특성 상 사용자는 이메일을 수정할 수 없음
     - 이메일의 불일치로 인한 문제는 발생하지 않으며, 이메일을 필드에 추가함으로써 채팅방 1번의 쿼리를 절약할 수 있음
