### PR TITLE
이미지 업로드 api 작성

### DIFF
--- a/src/main/java/com/windmeal/global/controller/ImageController.java
+++ b/src/main/java/com/windmeal/global/controller/ImageController.java
@@ -9,6 +9,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
@@ -22,6 +23,7 @@ import org.springframework.web.multipart.MultipartFile;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/image")
+@Tag(name = "이미지", description = "이미지 관련 api 입니다.")
 public class ImageController {
 
     private final S3Util s3Util;

--- a/src/main/java/com/windmeal/global/controller/ImageController.java
+++ b/src/main/java/com/windmeal/global/controller/ImageController.java
@@ -1,0 +1,45 @@
+package com.windmeal.global.controller;
+
+import com.windmeal.global.S3.S3Util;
+import com.windmeal.global.exception.ExceptionResponseDTO;
+import com.windmeal.global.exception.ResultDataResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/image")
+public class ImageController {
+
+    private final S3Util s3Util;
+
+    @Operation(summary = "파일 업로드 요청", description = "파일을 업로드합니다.",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)
+            ))
+    @ApiResponses({
+            @ApiResponse(responseCode = "201", description = "CREATED"),
+            @ApiResponse(responseCode = "400", description = "이미지만 업로드할 수 있습니다.",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponseDTO.class))),
+            @ApiResponse(responseCode = "503", description = "서버 내부 에러",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponseDTO.class)))})
+    @PostMapping
+    public ResultDataResponseDTO<String> uploadFile(
+            @Parameter(description = "이미지 파일", required = false, schema = @Schema(type = "string", format = "binary"))
+            @RequestPart(value = "file", required = false) MultipartFile file) {
+        return ResultDataResponseDTO.of(s3Util.imgUpload(file));
+    }
+}


### PR DESCRIPTION
### PR 타입

- [x] 기능 추가

## 작업사항
- 이미지 업로드 api 작성 (2aa44ea7c63ff729954e828c20127d71f3141e92)
     - 채팅 메시지에 들어갈 이미지를 업로드하는 api.
     - 임시로 작성했으며, 추후 채팅서버에서 직접 이미지를 업로드할 방안을 찾을 예정이다.
