### PR TITLE
프론트엔드 요구사항 반영 - 가게, 주문정보 지도 관련 api

### DIFF
--- a/src/main/java/com/windmeal/global/configuration/WebConfig.java
+++ b/src/main/java/com/windmeal/global/configuration/WebConfig.java
@@ -1,8 +1,10 @@
 
 package com.windmeal.global.configuration;
 
+import com.windmeal.global.converter.OrderStatusConverter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -20,6 +22,10 @@ public class WebConfig implements WebMvcConfigurer {
   @Value("${domain.url.ws_host}")
   private String ws_host;
 
+  @Override
+  public void addFormatters(FormatterRegistry registry) {
+    registry.addConverter(new OrderStatusConverter());
+  }
 
   @Override
   public void addCorsMappings(CorsRegistry registry) {

--- a/src/main/java/com/windmeal/global/converter/OrderStatusConverter.java
+++ b/src/main/java/com/windmeal/global/converter/OrderStatusConverter.java
@@ -1,0 +1,12 @@
+package com.windmeal.global.converter;
+
+import com.windmeal.order.domain.OrderStatus;
+import org.springframework.core.convert.converter.Converter;
+
+public class OrderStatusConverter implements Converter<String, OrderStatus> {
+
+    @Override
+    public OrderStatus convert(String source) {
+        return OrderStatus.of(source);
+    }
+}

--- a/src/main/java/com/windmeal/order/controller/OrderController.java
+++ b/src/main/java/com/windmeal/order/controller/OrderController.java
@@ -5,6 +5,7 @@ import com.windmeal.global.exception.ExceptionResponseDTO;
 import com.windmeal.global.exception.ResultDataResponseDTO;
 import com.windmeal.global.util.SecurityUtil;
 import com.windmeal.global.wrapper.RestSlice;
+import com.windmeal.order.domain.OrderStatus;
 import com.windmeal.order.dto.request.OrderCreateRequest;
 import com.windmeal.order.dto.request.OrderDeleteRequest;
 import com.windmeal.order.dto.response.OrderDetailResponse;
@@ -22,6 +23,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -33,6 +35,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
+@Slf4j
 @Tag(name = "주문 카테고리", description = "주문 관련 api 입니다.")
 @RestController
 @RequiredArgsConstructor
@@ -114,11 +117,12 @@ public class OrderController {
       @Parameter(description = "도착 예정 시간", required = false, schema = @Schema(example = "23:10:00"))
       @RequestParam(required = false) String eta,
       @Parameter(description = "검색 키워드", required = false, schema = @Schema(example = "카페"))
-      @RequestParam(required = false) String storeCategory
+      @RequestParam(required = false) String storeCategory,
+      @Parameter(description = "주문 상태", required = false, schema = @Schema(example = "ORDERED (대소문자 모두 가능)"))
+      @RequestParam(required = false, defaultValue = "ORDERED")OrderStatus orderStatus
   ){
     List<OrderMapListResponse> orders = orderService.getAllOrdersForMap(storeId, eta,
-        storeCategory, placeId);
-
+        storeCategory, placeId, orderStatus);
     return ResultDataResponseDTO.of(orders);
   }
 

--- a/src/main/java/com/windmeal/order/domain/OrderStatus.java
+++ b/src/main/java/com/windmeal/order/domain/OrderStatus.java
@@ -16,4 +16,22 @@ public enum OrderStatus {
      public String getStatus() {
           return this.status;
      }
+
+     public static OrderStatus of(String source) {
+          if (source == null) {
+               return null;
+          }
+          switch (source.toUpperCase()) {
+               case "ORDERED":
+                    return OrderStatus.ORDERED;
+               case "DELIVERING":
+                    return OrderStatus.DELIVERING;
+               case "DELIVERED":
+                    return OrderStatus.DELIVERED;
+               case "CANCELED":
+                    return OrderStatus.CANCELED;
+               default:
+                    throw new IllegalArgumentException("일치하는 주문 상태가 존재하지 않습니다.");
+          }
+     }
 }

--- a/src/main/java/com/windmeal/order/repository/order/OrderCustomRepository.java
+++ b/src/main/java/com/windmeal/order/repository/order/OrderCustomRepository.java
@@ -1,6 +1,7 @@
 package com.windmeal.order.repository.order;
 
 import com.windmeal.global.wrapper.RestSlice;
+import com.windmeal.order.domain.OrderStatus;
 import com.windmeal.order.dto.response.OrderListResponse;
 import com.windmeal.order.dto.response.OrderMapListResponse;
 import com.windmeal.order.dto.response.OwnOrderListResponse;
@@ -12,7 +13,7 @@ import org.springframework.data.domain.Slice;
 public interface OrderCustomRepository {
 
   List<OrderMapListResponse> getOrderMapList(Long storeId, String eta,
-      String storeCategory, Long placeId);
+      String storeCategory, Long placeId, OrderStatus orderStatus);
 
   RestSlice<OrderListResponse> getOrderList(Pageable pageable, Long storeId, String eta, String storeCategory,
       Long point, Long memberId);

--- a/src/main/java/com/windmeal/order/repository/order/OrderCustomRepositoryImpl.java
+++ b/src/main/java/com/windmeal/order/repository/order/OrderCustomRepositoryImpl.java
@@ -22,6 +22,7 @@ import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
@@ -34,7 +35,7 @@ public class OrderCustomRepositoryImpl implements OrderCustomRepository {
 
   @Override
   public List<OrderMapListResponse> getOrderMapList(Long storeId, String eta,
-      String storeCategory, Long placeId){
+      String storeCategory, Long placeId, OrderStatus orderStatus){
 
     return jpaQueryFactory.select(Projections.constructor(
         OrderMapListResponse.class,
@@ -46,7 +47,7 @@ public class OrderCustomRepositoryImpl implements OrderCustomRepository {
         ))
         .from(order)
         .leftJoin(store).on(store.id.eq(order.store_id))
-        .where(eqStoreId(storeId), eqEta(eta), eqStoreCategory(storeCategory), eqPlace(placeId),eqOrderStatus(OrderStatus.ORDERED))
+        .where(eqStoreId(storeId), eqEta(eta), eqStoreCategory(storeCategory), eqPlace(placeId),eqOrderStatus(orderStatus))
         .groupBy(order.store_id).fetch();
   }
 
@@ -199,7 +200,10 @@ public class OrderCustomRepositoryImpl implements OrderCustomRepository {
   }
 
   private BooleanExpression eqOrderStatus(OrderStatus orderStatus) {
-    return order.orderStatus.eq(orderStatus);
+    if(orderStatus != null) {
+      return order.orderStatus.eq(orderStatus);
+    }
+    return null;
   }
 
   private BooleanExpression eqBlackList(Long memberId) {

--- a/src/main/java/com/windmeal/order/service/OrderService.java
+++ b/src/main/java/com/windmeal/order/service/OrderService.java
@@ -106,8 +106,8 @@ public class OrderService {
   @Cacheable(value = "Orders", key = "0",cacheManager = "contentCacheManager",
             condition = "#storeId == null&&#eta==null&&#storeCategory==null&&#placeId==null")
   public List<OrderMapListResponse> getAllOrdersForMap(Long storeId, String eta, String storeCategory,
-      Long placeId) {
-    return orderRepository.getOrderMapList(storeId,eta,storeCategory,placeId);
+      Long placeId, OrderStatus orderStatus) {
+    return orderRepository.getOrderMapList(storeId,eta,storeCategory,placeId,orderStatus);
   }
   /**
    * 주문 상세 내용 조회

--- a/src/main/java/com/windmeal/store/controller/StoreController.java
+++ b/src/main/java/com/windmeal/store/controller/StoreController.java
@@ -152,9 +152,11 @@ public class StoreController {
           @Parameter(description = "검색 키워드", required = false, schema = @Schema(example = "카페"))
           @RequestParam(required = false) String storeCategory,
           @Parameter(description = "주문 상태", required = false, schema = @Schema(example = "ORDERED (대소문자 모두 가능)"))
-          @RequestParam(required = false) OrderStatus orderStatus
+          @RequestParam(required = false) OrderStatus orderStatus,
+          @Parameter(description = "영업 중 여부", required = false, schema = @Schema(example = "true"))
+          @RequestParam(required = false) Boolean isOpen
   ){
-    return ResultDataResponseDTO.of(storeService.getAllStoresForMap(storeId, eta, storeCategory, placeId, orderStatus));
+    return ResultDataResponseDTO.of(storeService.getAllStoresForMap(storeId, eta, storeCategory, placeId, orderStatus, isOpen));
   }
 
   @Operation(summary = "가게 정보 조회(CMS)", description = "가게 정보가 조회됩니다.")

--- a/src/main/java/com/windmeal/store/controller/StoreController.java
+++ b/src/main/java/com/windmeal/store/controller/StoreController.java
@@ -4,6 +4,8 @@ import com.windmeal.global.S3.S3Util;
 import com.windmeal.global.exception.ErrorCode;
 import com.windmeal.global.exception.ExceptionResponseDTO;
 import com.windmeal.global.exception.ResultDataResponseDTO;
+import com.windmeal.order.domain.OrderStatus;
+import com.windmeal.order.dto.response.OrderMapListResponse;
 import com.windmeal.store.dto.request.StoreCategoryCreateRequest;
 import com.windmeal.store.dto.request.StoreCreateRequest;
 import com.windmeal.store.dto.request.StoreUpdateRequest;
@@ -27,6 +29,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import javax.validation.Valid;
+import java.util.List;
 
 /**
  * 가게 생성 가게 정보 수정(이미지 제외) 가게 이미지 수정 가게 삭제 가게 정보 조회
@@ -133,8 +136,26 @@ public class StoreController {
     return ResultDataResponseDTO.of(storeService.getAllStoreInfo(pageable));
   }
 
-
-
+  @Operation(summary = "지도 상에서 보여줄 가게와 해당 가게의 주문수 조회", description = "지도 상에서 보여줄 가게와 해당 가게의 주문수를 조회합니다.")
+  @ApiResponses({
+          @ApiResponse(responseCode = "200", description = "OK"),
+          @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근",
+                  content = @Content(schema = @Schema(implementation = ExceptionResponseDTO.class)))})
+  @GetMapping("/store/map")
+  public ResultDataResponseDTO<List<OrderMapListResponse>> getAllStoresForMap(
+          @Parameter(description = "가게 id", required = false, schema = @Schema(example = "1"))
+          @RequestParam(required = false) Long storeId,
+          @Parameter(description = "도착지 id", required = false, schema = @Schema(example = "1"))
+          @RequestParam(required = false) Long placeId,
+          @Parameter(description = "도착 예정 시간", required = false, schema = @Schema(example = "23:10:00"))
+          @RequestParam(required = false) String eta,
+          @Parameter(description = "검색 키워드", required = false, schema = @Schema(example = "카페"))
+          @RequestParam(required = false) String storeCategory,
+          @Parameter(description = "주문 상태", required = false, schema = @Schema(example = "ORDERED (대소문자 모두 가능)"))
+          @RequestParam(required = false) OrderStatus orderStatus
+  ){
+    return ResultDataResponseDTO.of(storeService.getAllStoresForMap(storeId, eta, storeCategory, placeId, orderStatus));
+  }
 
   @Operation(summary = "가게 정보 조회(CMS)", description = "가게 정보가 조회됩니다.")
   @ApiResponses({

--- a/src/main/java/com/windmeal/store/controller/StoreController.java
+++ b/src/main/java/com/windmeal/store/controller/StoreController.java
@@ -154,7 +154,7 @@ public class StoreController {
           @Parameter(description = "주문 상태", required = false, schema = @Schema(example = "ORDERED (대소문자 모두 가능)"))
           @RequestParam(required = false) OrderStatus orderStatus,
           @Parameter(description = "영업 중 여부", required = false, schema = @Schema(example = "true"))
-          @RequestParam(required = false) Boolean isOpen
+          @RequestParam(required = false, defaultValue = "false") Boolean isOpen
   ){
     return ResultDataResponseDTO.of(storeService.getAllStoresForMap(storeId, eta, storeCategory, placeId, orderStatus, isOpen));
   }

--- a/src/main/java/com/windmeal/store/controller/StoreController.java
+++ b/src/main/java/com/windmeal/store/controller/StoreController.java
@@ -24,7 +24,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -34,9 +33,9 @@ import java.util.List;
 /**
  * 가게 생성 가게 정보 수정(이미지 제외) 가게 이미지 수정 가게 삭제 가게 정보 조회
  */
-@Tag(name = "가게", description = "가게 관련 api 입니다.")
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "가게", description = "가게 관련 api 입니다.")
 public class StoreController {
 
   private final StoreService storeService;
@@ -138,23 +137,23 @@ public class StoreController {
 
   @Operation(summary = "지도 상에서 보여줄 가게와 해당 가게의 주문수 조회", description = "지도 상에서 보여줄 가게와 해당 가게의 주문수를 조회합니다.")
   @ApiResponses({
-          @ApiResponse(responseCode = "200", description = "OK"),
-          @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근",
-                  content = @Content(schema = @Schema(implementation = ExceptionResponseDTO.class)))})
+      @ApiResponse(responseCode = "200", description = "OK"),
+      @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스 접근",
+          content = @Content(schema = @Schema(implementation = ExceptionResponseDTO.class)))})
   @GetMapping("/store/map")
   public ResultDataResponseDTO<List<OrderMapListResponse>> getAllStoresForMap(
-          @Parameter(description = "가게 id", required = false, schema = @Schema(example = "1"))
-          @RequestParam(required = false) Long storeId,
-          @Parameter(description = "도착지 id", required = false, schema = @Schema(example = "1"))
-          @RequestParam(required = false) Long placeId,
-          @Parameter(description = "도착 예정 시간", required = false, schema = @Schema(example = "23:10:00"))
-          @RequestParam(required = false) String eta,
-          @Parameter(description = "검색 키워드", required = false, schema = @Schema(example = "카페"))
-          @RequestParam(required = false) String storeCategory,
-          @Parameter(description = "주문 상태", required = false, schema = @Schema(example = "ORDERED (대소문자 모두 가능)"))
-          @RequestParam(required = false) OrderStatus orderStatus,
-          @Parameter(description = "영업 중 여부", required = false, schema = @Schema(example = "true"))
-          @RequestParam(required = false, defaultValue = "false") Boolean isOpen
+      @Parameter(description = "가게 id", required = false, schema = @Schema(example = "1"))
+      @RequestParam(required = false) Long storeId,
+      @Parameter(description = "도착지 id", required = false, schema = @Schema(example = "1"))
+      @RequestParam(required = false) Long placeId,
+      @Parameter(description = "도착 예정 시간", required = false, schema = @Schema(example = "23:10:00"))
+      @RequestParam(required = false) String eta,
+      @Parameter(description = "검색 키워드", required = false, schema = @Schema(example = "카페"))
+      @RequestParam(required = false) String storeCategory,
+      @Parameter(description = "주문 상태", required = false, schema = @Schema(example = "ORDERED (대소문자 모두 가능)"))
+      @RequestParam(required = false) OrderStatus orderStatus,
+      @Parameter(description = "영업 중 여부", required = false, schema = @Schema(example = "true"))
+      @RequestParam(required = false, defaultValue = "false") Boolean isOpen
   ){
     return ResultDataResponseDTO.of(storeService.getAllStoresForMap(storeId, eta, storeCategory, placeId, orderStatus, isOpen));
   }

--- a/src/main/java/com/windmeal/store/repository/StoreCustomRepository.java
+++ b/src/main/java/com/windmeal/store/repository/StoreCustomRepository.java
@@ -13,5 +13,5 @@ public interface StoreCustomRepository {
     Slice<AllStoreResponse> getAllStoreInfo(Pageable pageable);
 
     List<OrderMapListResponse> getStoreMapList(Long storeId, String eta,
-                                               String storeCategory, Long placeId, OrderStatus orderStatus);
+                                               String storeCategory, Long placeId, OrderStatus orderStatus, Boolean isOpen);
 }

--- a/src/main/java/com/windmeal/store/repository/StoreCustomRepository.java
+++ b/src/main/java/com/windmeal/store/repository/StoreCustomRepository.java
@@ -1,10 +1,17 @@
 package com.windmeal.store.repository;
 
+import com.windmeal.order.domain.OrderStatus;
+import com.windmeal.order.dto.response.OrderMapListResponse;
 import com.windmeal.store.dto.response.AllStoreResponse;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 
+import java.util.List;
+
 public interface StoreCustomRepository {
 
-  Slice<AllStoreResponse> getAllStoreInfo(Pageable pageable);
+    Slice<AllStoreResponse> getAllStoreInfo(Pageable pageable);
+
+    List<OrderMapListResponse> getStoreMapList(Long storeId, String eta,
+                                               String storeCategory, Long placeId, OrderStatus orderStatus);
 }

--- a/src/main/java/com/windmeal/store/repository/StoreCustomRepositoryImpl.java
+++ b/src/main/java/com/windmeal/store/repository/StoreCustomRepositoryImpl.java
@@ -69,7 +69,7 @@ public class StoreCustomRepositoryImpl implements StoreCustomRepository {
         LocalTime end = LocalTime.MAX;
         if (eta != null) {
             start = LocalTime.parse(eta);
-            end = LocalTime.parse(eta).plus(1, ChronoUnit.MINUTES);
+            end = LocalTime.parse(eta).plus(10, ChronoUnit.MINUTES);
         }
         return order.eta.between(now.atTime(start),now.atTime(end));
     }

--- a/src/main/java/com/windmeal/store/repository/StoreCustomRepositoryImpl.java
+++ b/src/main/java/com/windmeal/store/repository/StoreCustomRepositoryImpl.java
@@ -1,35 +1,120 @@
 package com.windmeal.store.repository;
 
+import static com.windmeal.order.domain.QOrder.*;
+import static com.windmeal.store.domain.QCategory.category;
 import static com.windmeal.store.domain.QStore.store;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.windmeal.order.domain.OrderStatus;
+import com.windmeal.order.domain.QOrder;
+import com.windmeal.order.dto.response.OrderMapListResponse;
+import com.windmeal.store.domain.QStore;
+import com.windmeal.store.domain.QStoreCategory;
 import com.windmeal.store.dto.response.AllStoreResponse;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 
 @RequiredArgsConstructor
-public class StoreCustomRepositoryImpl implements StoreCustomRepository{
-  private final JPAQueryFactory jpaQueryFactory;
+public class StoreCustomRepositoryImpl implements StoreCustomRepository {
+    private final JPAQueryFactory jpaQueryFactory;
 
-  @Override
-  public Slice<AllStoreResponse> getAllStoreInfo(Pageable pageable) {
-    List<AllStoreResponse> content = jpaQueryFactory.select(
-            Projections.constructor(AllStoreResponse.class,
-                store.id,
-                store.name)
-        )
-        .from(store)
-        .offset(pageable.getOffset())
-        .limit(pageable.getPageSize() + 1).fetch();
-    boolean hasNext = false;
-    if (content.size() > pageable.getPageSize()) {
-      content.remove(pageable.getPageSize());
-      hasNext = true;
+    @Override
+    public Slice<AllStoreResponse> getAllStoreInfo(Pageable pageable) {
+        List<AllStoreResponse> content = jpaQueryFactory.select(
+                        Projections.constructor(AllStoreResponse.class,
+                                store.id,
+                                store.name)
+                )
+                .from(store)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize() + 1).fetch();
+        boolean hasNext = false;
+        if (content.size() > pageable.getPageSize()) {
+            content.remove(pageable.getPageSize());
+            hasNext = true;
+        }
+        return new SliceImpl(content, pageable, hasNext);
     }
-    return new SliceImpl(content, pageable, hasNext);
-  }
+
+    @Override
+    public List<OrderMapListResponse> getStoreMapList(Long storeId, String eta, String storeCategory, Long placeId, OrderStatus orderStatus) {
+        return jpaQueryFactory
+                .select(Projections.constructor(
+                        OrderMapListResponse.class,
+                        store.id,
+                        store.name,
+                        order.id.count(),
+                        store.place.longitude,
+                        store.place.latitude
+                ))
+                .from(store)
+                .leftJoin(order).on(store.id.eq(order.store_id))
+                .where(eqStoreId(storeId), eqEta(eta), eqStoreCategory(storeCategory), eqPlace(placeId), eqOrderStatus(orderStatus))
+                .groupBy(store.id).fetch();
+    }
+
+    private BooleanExpression eqEta(String eta) {
+        LocalDate now = LocalDate.now();
+        LocalTime start = LocalTime.MIN;
+        LocalTime end = LocalTime.MAX;
+        if (eta != null) {
+            start = LocalTime.parse(eta);
+            end = LocalTime.parse(eta).plus(1, ChronoUnit.MINUTES);
+        }
+        return order.eta.between(now.atTime(start),now.atTime(end));
+    }
+
+
+    private BooleanExpression eqStoreId(Long storeId) {
+        if (storeId != null) {
+            return order.store_id.eq(storeId);
+        }
+        return null;
+    }
+
+    private BooleanExpression eqOrderStatus(OrderStatus orderStatus) {
+        if(orderStatus != null) {
+            return order.orderStatus.eq(orderStatus);
+        }
+        return null;
+    }
+
+    private BooleanExpression eqPlace(Long placeId) {
+        if(placeId==null){
+            return null;
+        }else{
+            return order.place.id.eq(placeId);
+        }
+
+    }
+
+    private List<Long> getCategoryIds(String storeCategory) {
+        return jpaQueryFactory.select(category.id)
+                .from(category)
+                .where(category.name.contains(storeCategory)).fetch(); //storeCategory 가 포함되는 category_id 조회
+    }
+
+    //음식 종류로 검색(text로 검색 예정)
+    private BooleanExpression eqStoreCategory(String storeCategory) {
+        if (storeCategory == null) {
+            return null;
+        } else {
+            return order.store_id.in(
+                    jpaQueryFactory
+                            .select(QStoreCategory.storeCategory.store.id)
+                            .from(QStoreCategory.storeCategory)
+                            .where(QStoreCategory.storeCategory.category.id.in(getCategoryIds(storeCategory)))
+                            .fetch());
+        }
+    }
 }

--- a/src/main/java/com/windmeal/store/service/StoreService.java
+++ b/src/main/java/com/windmeal/store/service/StoreService.java
@@ -110,8 +110,8 @@ public class StoreService {
     return storeRepository.getAllStoreInfo(pageable);
   }
 
-  public List<OrderMapListResponse> getAllStoresForMap(Long storeId, String eta, String storeCategory, Long placeId, OrderStatus orderStatus) {
-      return storeRepository.getStoreMapList(storeId, eta, storeCategory, placeId, orderStatus);
+  public List<OrderMapListResponse> getAllStoresForMap(Long storeId, String eta, String storeCategory, Long placeId, OrderStatus orderStatus, Boolean isOpen) {
+      return storeRepository.getStoreMapList(storeId, eta, storeCategory, placeId, orderStatus, isOpen);
   }
 
   public CategoryStoreMenuResponse getStoreInfoForCms(Long storeId) {

--- a/src/main/java/com/windmeal/store/service/StoreService.java
+++ b/src/main/java/com/windmeal/store/service/StoreService.java
@@ -110,6 +110,8 @@ public class StoreService {
     return storeRepository.getAllStoreInfo(pageable);
   }
 
+  @Cacheable(value = "Orders", key = "0",cacheManager = "contentCacheManager",
+      condition = "#storeId == null&&#eta==null&&#storeCategory==null&&#placeId==null&&#orderStatus==null&&#isOpen==false")
   public List<OrderMapListResponse> getAllStoresForMap(Long storeId, String eta, String storeCategory, Long placeId, OrderStatus orderStatus, Boolean isOpen) {
       return storeRepository.getStoreMapList(storeId, eta, storeCategory, placeId, orderStatus, isOpen);
   }

--- a/src/main/java/com/windmeal/store/service/StoreService.java
+++ b/src/main/java/com/windmeal/store/service/StoreService.java
@@ -7,6 +7,8 @@ import com.windmeal.member.exception.MemberNotFoundException;
 import com.windmeal.member.repository.MemberRepository;
 import com.windmeal.model.place.Place;
 import com.windmeal.model.place.PlaceRepository;
+import com.windmeal.order.domain.OrderStatus;
+import com.windmeal.order.dto.response.OrderMapListResponse;
 import com.windmeal.store.domain.Category;
 import com.windmeal.store.domain.MenuCategory;
 import com.windmeal.store.domain.Store;
@@ -106,6 +108,10 @@ public class StoreService {
 
   public Slice<AllStoreResponse> getAllStoreInfo(Pageable pageable){
     return storeRepository.getAllStoreInfo(pageable);
+  }
+
+  public List<OrderMapListResponse> getAllStoresForMap(Long storeId, String eta, String storeCategory, Long placeId, OrderStatus orderStatus) {
+      return storeRepository.getStoreMapList(storeId, eta, storeCategory, placeId, orderStatus);
   }
 
   public CategoryStoreMenuResponse getStoreInfoForCms(Long storeId) {


### PR DESCRIPTION
### PR 타입

- [x] 기능 추가

## 작업사항
- store 도메인에 가게, 주문정보에 대한 지도 관련 api 작성
     - 기존 api는 order 도메인에 대해서 쿼리하지만, 주문정보가 없는 store에 대해서도 조회해야 하기 때문에 store 도메인에 대해서 쿼리 실시 (664510a3604ba60f4228de5f84cdec43dd0c16f2)
     - 영업중 상태에 대해서도 고려 (404364db091dd591522a920c394e3edcb304b423)
     - eta(도착시간)에 대한 조회 범위가 내부 논의 결과 10분 단위로 변경됨. 해당 사항도 코드로 반영 (c3a967e0c1b6b86cc8c2f701da225a86804c3686)
     - 필터링이 아무것도 걸려있지 않은 전체 데이터 조회에 대해서는 캐시 적용 (b514c9e936248b485291de9478184344cbcf2796)


## TODO
+ 현재 쿼리는 전체 데이터를 대상으로 페이지네이션 없이 모든 데이터를 가져옴.
+ 실제 서비스에서는 확대의 정도에 따라 범위를 정해 해당 범위 내에서 최대값을 정해서 그 값 만큼만 조회가 이루어져야 함.