### PR TITLE
메인 화면 지도 관련 API 수정

### DIFF
--- a/src/main/java/com/windmeal/store/controller/StoreController.java
+++ b/src/main/java/com/windmeal/store/controller/StoreController.java
@@ -151,7 +151,7 @@ public class StoreController {
       @Parameter(description = "검색 키워드", required = false, schema = @Schema(example = "카페"))
       @RequestParam(required = false) String storeCategory,
       @Parameter(description = "주문 상태", required = false, schema = @Schema(example = "ORDERED (대소문자 모두 가능)"))
-      @RequestParam(required = false) OrderStatus orderStatus,
+      @RequestParam(required = false, defaultValue = "ORDERED") OrderStatus orderStatus,
       @Parameter(description = "영업 중 여부", required = false, schema = @Schema(example = "true"))
       @RequestParam(required = false, defaultValue = "false") Boolean isOpen
   ){

--- a/src/main/java/com/windmeal/store/repository/StoreCustomRepositoryImpl.java
+++ b/src/main/java/com/windmeal/store/repository/StoreCustomRepositoryImpl.java
@@ -48,7 +48,8 @@ public class StoreCustomRepositoryImpl implements StoreCustomRepository {
     }
 
     @Override
-    public List<OrderMapListResponse> getStoreMapList(Long storeId, String eta, String storeCategory, Long placeId, OrderStatus orderStatus, Boolean isOpen) {
+    public List<OrderMapListResponse> getStoreMapList(Long storeId, String eta,
+        String storeCategory, Long placeId, OrderStatus orderStatus, Boolean isOpen) {
         return jpaQueryFactory
             .select(Projections.constructor(
                 OrderMapListResponse.class,
@@ -59,20 +60,22 @@ public class StoreCustomRepositoryImpl implements StoreCustomRepository {
                 store.place.latitude
             ))
             .from(store)
-            .leftJoin(order).on(store.id.eq(order.store_id))
-            .where(eqStoreId(storeId), eqEta(eta), eqStoreCategory(storeCategory), eqPlace(placeId), eqOrderStatus(orderStatus), eqOpen(isOpen))
+            .leftJoin(order).on(store.id.eq(order.store_id)).on(eqOrderStatus(orderStatus))
+            .where(eqStoreId(storeId), eqEta(eta), eqStoreCategory(storeCategory),
+                eqPlace(placeId), eqOpen(isOpen))
             .groupBy(store.id).fetch();
     }
 
     private BooleanExpression eqEta(String eta) {
-        LocalDate now = LocalDate.now();
-        LocalTime start = LocalTime.MIN;
-        LocalTime end = LocalTime.MAX;
+//        LocalTime start = LocalTime.MIN;
+//        LocalTime end = LocalTime.MAX;
         if (eta != null) {
-            start = LocalTime.parse(eta);
-            end = LocalTime.parse(eta).plus(10, ChronoUnit.MINUTES);
+            LocalDate now = LocalDate.now();
+            LocalTime start = LocalTime.parse(eta);
+            LocalTime end = LocalTime.parse(eta).plus(10, ChronoUnit.MINUTES);
+            return order.eta.between(now.atTime(start),now.atTime(end));
         }
-        return order.eta.between(now.atTime(start),now.atTime(end));
+        return null;
     }
 
 

--- a/src/main/java/com/windmeal/store/service/StoreService.java
+++ b/src/main/java/com/windmeal/store/service/StoreService.java
@@ -112,8 +112,10 @@ public class StoreService {
 
   @Cacheable(value = "Orders", key = "0",cacheManager = "contentCacheManager",
       condition = "#storeId == null&&#eta==null&&#storeCategory==null&&#placeId==null&&#orderStatus==null&&#isOpen==false")
-  public List<OrderMapListResponse> getAllStoresForMap(Long storeId, String eta, String storeCategory, Long placeId, OrderStatus orderStatus, Boolean isOpen) {
-      return storeRepository.getStoreMapList(storeId, eta, storeCategory, placeId, orderStatus, isOpen);
+  public List<OrderMapListResponse> getAllStoresForMap(Long storeId, String eta,
+      String storeCategory, Long placeId, OrderStatus orderStatus, Boolean isOpen) {
+      return storeRepository.getStoreMapList(
+          storeId, eta, storeCategory, placeId, orderStatus, isOpen);
   }
 
   public CategoryStoreMenuResponse getStoreInfoForCms(Long storeId) {


### PR DESCRIPTION
### PR 타입

- [x] 기능 수정

## 작업사항
- 메인 화면 지도 관련 API 수정 (f63cc490a54d3bbdc3c4fa8c67bb6805efbaa12c)
     - 쿼리 수정
     - 기존 쿼리는 주문 상태가 ordered인 데이터를 조회하려고 하면 주문이 없는 가게는 조회되지 않았고, 반대로 해당 조건을 풀어버리면 이미 완료된 주문까지 모두 조회되었음
