### PR TITLE
메인화면 지도 api 이슈 해결

### DIFF
--- a/src/main/java/com/windmeal/model/place/PlaceRepository.java
+++ b/src/main/java/com/windmeal/model/place/PlaceRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface PlaceRepository extends JpaRepository<Place, Long>{
 
   Optional<Place> findByNameAndLongitudeAndLatitude(String name,Double longitude, Double latitude);
+  Optional<Place> findByName(String name);
+  Boolean existsByName(String name);
 }

--- a/src/main/java/com/windmeal/order/exception/InvalidPlaceNameException.java
+++ b/src/main/java/com/windmeal/order/exception/InvalidPlaceNameException.java
@@ -1,0 +1,10 @@
+package com.windmeal.order.exception;
+
+import com.windmeal.global.exception.ErrorCode;
+import com.windmeal.global.exception.GeneralException;
+
+public class InvalidPlaceNameException extends GeneralException {
+    public InvalidPlaceNameException() {
+        super(ErrorCode.BAD_REQUEST, "이미 존재하는 장소명입니다.");
+    }
+}

--- a/src/main/java/com/windmeal/store/service/StoreService.java
+++ b/src/main/java/com/windmeal/store/service/StoreService.java
@@ -58,7 +58,7 @@ public class StoreService {
   @Transactional
   public StoreResponse createStore(StoreCreateRequest request, String imgUrl) {
     Member findMember = memberRepository.findById(request.getMemberId())
-        .orElseThrow(() -> new MemberNotFoundException()); //Member Not Found 예외 추가 예정
+        .orElseThrow(MemberNotFoundException::new); //Member Not Found 예외 추가 예정
     Place place = placeRepository.findByNameAndLongitudeAndLatitude(request.getPlaceName(),request.getLongitude(),request.getLatitude())
         .orElseGet(() -> placeRepository.save(request.toPlaceEntity()));
 


### PR DESCRIPTION
### PR 타입

- [x] 기능 수정

## 작업사항
- 데이터베이스에 존재하지 않는 storeCategory를 검색 기준으로 설정하여 검색할 경우, SQL 에러가 발생하던 문제 해결 (0543dae88b5c024148645fd7fafc9b4f507b0570)
     - BooleanExpressions.FALSE로 조건문에 false 처리를 해주고 싶었으나, SQL Exception이 발생
     - 임의로 성립 불가능한 조건을 추가하여 원하는 대로 동작은 하게 수정. 더 나은 방법을 생각해보아야 함.
- 도착지 관련 정책 수정으로 인한 관련 로직 수정 (3e3b9e762305ad46f7337caaac943fcc02d55dbc)
     - 기존 도착지의 경우 이름,위도,경도로 이루어진 후보키를 통해 유일하게 조회함
     - 바뀐 정책에서는 이름의 중복을 확인하고, 중복된 이름으로는 도착지를 생성할 수 없게 설정.
