### PR TITLE
프론트엔드 요구사항 반영

### DIFF
--- a/src/main/java/com/windmeal/order/controller/OrderController.java
+++ b/src/main/java/com/windmeal/order/controller/OrderController.java
@@ -104,28 +104,6 @@ public class OrderController {
   }
 
 
-  @Operation(summary = "주문 내역 조회 - 지도", description = "주문 내역 리스트를 조회합니다.")
-  @ApiResponses({
-      @ApiResponse(responseCode = "200", description = "OK")
-  })
-  @GetMapping("/order/map")
-  public ResultDataResponseDTO<List<OrderMapListResponse>> getAllOrdersForMap(
-      @Parameter(description = "가게 id", required = false, schema = @Schema(example = "1"))
-      @RequestParam(required = false) Long storeId,
-      @Parameter(description = "도착지 id", required = false, schema = @Schema(example = "1"))
-      @RequestParam(required = false) Long placeId,
-      @Parameter(description = "도착 예정 시간", required = false, schema = @Schema(example = "23:10:00"))
-      @RequestParam(required = false) String eta,
-      @Parameter(description = "검색 키워드", required = false, schema = @Schema(example = "카페"))
-      @RequestParam(required = false) String storeCategory,
-      @Parameter(description = "주문 상태", required = false, schema = @Schema(example = "ORDERED (대소문자 모두 가능)"))
-      @RequestParam(required = false, defaultValue = "ORDERED")OrderStatus orderStatus
-  ){
-    List<OrderMapListResponse> orders = orderService.getAllOrdersForMap(storeId, eta,
-        storeCategory, placeId, orderStatus);
-    return ResultDataResponseDTO.of(orders);
-  }
-
   @Operation(summary = "주문 내역 상세 조회", description = "주문 내역의 상세 내용을 조회합니다.")
   @ApiResponses({
       @ApiResponse(responseCode = "200", description = "OK"),

--- a/src/main/java/com/windmeal/order/dto/response/OrderListResponse.java
+++ b/src/main/java/com/windmeal/order/dto/response/OrderListResponse.java
@@ -2,7 +2,9 @@ package com.windmeal.order.dto.response;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
 import com.windmeal.generic.domain.Money;
 import com.windmeal.generic.domain.MoneyDeserializer;
@@ -40,7 +42,9 @@ public class OrderListResponse {
   @Schema(description = "위도", example = "1.2345")
   private Double latitude;
 
-
+  @JsonSerialize(using = LocalDateTimeSerializer.class)
+  @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+  private LocalDateTime orderTime;
 
   @JsonSerialize(using = LocalTimeSerializer.class)
   @JsonDeserialize(using = LocalTimeDeserializer.class)
@@ -60,7 +64,7 @@ public class OrderListResponse {
 
 
   public OrderListResponse(Long id, Long memberId, String memberNickName, String placeName,
-      Double longitude, Double latitude, LocalDateTime eta, Money deliveryFee, String name,
+      Double longitude, Double latitude, LocalDateTime orderTime, LocalDateTime eta, Money deliveryFee, String name,
       String summary) {
     this.id = id;
     this.memberId = memberId;
@@ -68,6 +72,7 @@ public class OrderListResponse {
     this.placeName = placeName;
     this.longitude = longitude;
     this.latitude = latitude;
+    this.orderTime = orderTime;
     this.eta = eta.toLocalTime();
     this.deliveryFee = deliveryFee;
     this.name = name;

--- a/src/main/java/com/windmeal/order/exception/InvalidPlaceNameException.java
+++ b/src/main/java/com/windmeal/order/exception/InvalidPlaceNameException.java
@@ -5,6 +5,6 @@ import com.windmeal.global.exception.GeneralException;
 
 public class InvalidPlaceNameException extends GeneralException {
     public InvalidPlaceNameException() {
-        super(ErrorCode.BAD_REQUEST, "이미 존재하는 장소명입니다.");
+        super(ErrorCode.BAD_REQUEST, "유효하지 않은 장소입니다.");
     }
 }

--- a/src/main/java/com/windmeal/order/repository/order/OrderCustomRepository.java
+++ b/src/main/java/com/windmeal/order/repository/order/OrderCustomRepository.java
@@ -12,9 +12,6 @@ import org.springframework.data.domain.Slice;
 
 public interface OrderCustomRepository {
 
-  List<OrderMapListResponse> getOrderMapList(Long storeId, String eta,
-      String storeCategory, Long placeId, OrderStatus orderStatus);
-
   RestSlice<OrderListResponse> getOrderList(Pageable pageable, Long storeId, String eta, String storeCategory,
       Long point, Long memberId);
   Integer getOwnOrderedTotalPrice(Long memberId);

--- a/src/main/java/com/windmeal/order/repository/order/OrderCustomRepositoryImpl.java
+++ b/src/main/java/com/windmeal/order/repository/order/OrderCustomRepositoryImpl.java
@@ -34,24 +34,6 @@ public class OrderCustomRepositoryImpl implements OrderCustomRepository {
   private final JPAQueryFactory jpaQueryFactory;
 
   @Override
-  public List<OrderMapListResponse> getOrderMapList(Long storeId, String eta,
-      String storeCategory, Long placeId, OrderStatus orderStatus){
-
-    return jpaQueryFactory.select(Projections.constructor(
-        OrderMapListResponse.class,
-            order.store_id,
-            store.name,
-            order.store_id.count(),
-            store.place.longitude,
-            store.place.latitude
-        ))
-        .from(order)
-        .leftJoin(store).on(store.id.eq(order.store_id))
-        .where(eqStoreId(storeId), eqEta(eta), eqStoreCategory(storeCategory), eqPlace(placeId),eqOrderStatus(orderStatus))
-        .groupBy(order.store_id).fetch();
-  }
-
-  @Override
   public RestSlice<OrderListResponse> getOrderList(Pageable pageable, Long storeId, String eta,
       String storeCategory, Long placeId, Long memberId) {
     List<OrderListResponse> content = jpaQueryFactory.select(Projections.constructor(
@@ -62,6 +44,7 @@ public class OrderCustomRepositoryImpl implements OrderCustomRepository {
             order.place.name,
             order.place.longitude,
             order.place.latitude,
+            order.orderTime,
             order.eta,
             order.deliveryFee,
             store.name,

--- a/src/main/java/com/windmeal/order/service/OrderService.java
+++ b/src/main/java/com/windmeal/order/service/OrderService.java
@@ -59,13 +59,8 @@ public class OrderService {
 
     orderValidator.validate(request);
     // 이름으로만 검색하도록 변경 : 도착지로만 쓰는거니까 상관이 없다.
-//    Place place = placeRepository.findByNameAndLongitudeAndLatitude(request.getPlaceName(),request.getLongitude(),request.getLatitude())
-//        .orElseGet(() -> placeRepository.save(request.toPlaceEntity()));
-    if(placeRepository.existsByName(request.getPlaceName())) {
-      throw new InvalidPlaceNameException();
-    }
     Place place = placeRepository.findByName(request.getPlaceName())
-        .orElseGet(() -> placeRepository.save(request.toPlaceEntity()));
+        .orElseThrow(InvalidPlaceNameException::new);
     Order order = orderRequestMapper.mapFrom(request);
     Money totalPrice = calculateTotalPrice(request);
     String summary = getSummary(totalPrice, request.getMenus().get(0).getName(), calculateTotalSize(request));
@@ -101,21 +96,6 @@ public class OrderService {
     return orderRepository.getOrderList(pageable,storeId,eta,storeCategory,placeId,memberId);
   }
 
-  /**
-   * 지도에 보여줄 데이터 조회
-   * 주문이 추가된 경우, 배달이 성사된 경우 캐시 초기화
-   * @param storeId
-   * @param eta
-   * @param storeCategory
-   * @param placeId
-   * @return
-   */
-  @Cacheable(value = "Orders", key = "0",cacheManager = "contentCacheManager",
-            condition = "#storeId == null&&#eta==null&&#storeCategory==null&&#placeId==null")
-  public List<OrderMapListResponse> getAllOrdersForMap(Long storeId, String eta, String storeCategory,
-      Long placeId, OrderStatus orderStatus) {
-    return orderRepository.getOrderMapList(storeId,eta,storeCategory,placeId,orderStatus);
-  }
   /**
    * 주문 상세 내용 조회
    * @param orderId

--- a/src/main/java/com/windmeal/store/repository/StoreCustomRepositoryImpl.java
+++ b/src/main/java/com/windmeal/store/repository/StoreCustomRepositoryImpl.java
@@ -62,9 +62,10 @@ public class StoreCustomRepositoryImpl implements StoreCustomRepository {
                 store.place.latitude
             ))
             .from(store)
-            .leftJoin(order).on(store.id.eq(order.store_id)).on(eqOrderStatus(orderStatus))
+            .leftJoin(order).on(store.id.eq(order.store_id)).on(
+                eqOrderStatus(orderStatus), eqOrderTime(LocalDateTime.now().toString()))
             .where(eqStoreId(storeId), eqEta(eta), eqStoreCategory(storeCategory),
-                eqPlace(placeId), eqOpen(isOpen), eqOrderTime(LocalDateTime.now().toString()))
+                eqPlace(placeId), eqOpen(isOpen))
             .groupBy(store.id).fetch();
     }
 

--- a/src/main/java/com/windmeal/store/repository/StoreCustomRepositoryImpl.java
+++ b/src/main/java/com/windmeal/store/repository/StoreCustomRepositoryImpl.java
@@ -1,32 +1,30 @@
 package com.windmeal.store.repository;
 
-import static com.windmeal.order.domain.QOrder.*;
-import static com.windmeal.store.domain.QCategory.category;
-import static com.windmeal.store.domain.QStore.store;
-
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.windmeal.global.util.TimeUtil;
 import com.windmeal.order.domain.OrderStatus;
 import com.windmeal.order.dto.response.OrderMapListResponse;
 import com.windmeal.store.domain.QStoreCategory;
 import com.windmeal.store.dto.response.AllStoreResponse;
-
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.ZoneId;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
-import java.util.ArrayList;
-import java.util.List;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import static com.windmeal.order.domain.QOrder.order;
+import static com.windmeal.store.domain.QCategory.category;
+import static com.windmeal.store.domain.QStore.store;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -66,7 +64,7 @@ public class StoreCustomRepositoryImpl implements StoreCustomRepository {
             .from(store)
             .leftJoin(order).on(store.id.eq(order.store_id)).on(eqOrderStatus(orderStatus))
             .where(eqStoreId(storeId), eqEta(eta), eqStoreCategory(storeCategory),
-                eqPlace(placeId), eqOpen(isOpen))
+                eqPlace(placeId), eqOpen(isOpen), eqOrderTime(LocalDateTime.now().toString()))
             .groupBy(store.id).fetch();
     }
 
@@ -78,6 +76,19 @@ public class StoreCustomRepositoryImpl implements StoreCustomRepository {
             LocalTime start = LocalTime.parse(eta);
             LocalTime end = LocalTime.parse(eta).plus(10, ChronoUnit.MINUTES);
             return order.eta.between(now.atTime(start),now.atTime(end));
+        }
+        return null;
+    }
+
+    private BooleanExpression eqOrderTime(String orderTime) {
+        //  "orderTime": "2024-03-06T02:16:06.68306",
+        // 오늘 날짜만 반환
+        if(orderTime != null) {
+            StringExpression formattedDate = Expressions.stringTemplate(
+                "FUNCTION('DATE_FORMAT', {0}, '%Y-%m-%d')", orderTime);
+            StringExpression orderTimeFormattedDate = Expressions.stringTemplate(
+                "FUNCTION('DATE_FORMAT', {0}, '%Y-%m-%d')", order.orderTime);
+            return formattedDate.eq(orderTimeFormattedDate);
         }
         return null;
     }


### PR DESCRIPTION
### PR 타입

- [x] 기능 수정

## 작업사항
- 주문 생성 시 도착지 검증 로직 수정
     - 데이터베이스에 존재하는 도착지만 허용해야 하는데, 반대로 설정되어 있었음.
- 지도에 보여지는 주문 데이터를 당일로 제한
- 주문 관련 api 응답값에 주문시간값 추가
     - "5분 전", "1일 전", ... 등의 정보를 출력하기 위함
