### PR TITLE
corsFilter 수정

### DIFF
--- a/src/main/java/com/windmeal/global/security/impl/filter/CustomCorsFilter.java
+++ b/src/main/java/com/windmeal/global/security/impl/filter/CustomCorsFilter.java
@@ -39,9 +39,10 @@ public class CustomCorsFilter implements Filter {
     HttpServletResponse response = (HttpServletResponse) res;
     HttpServletRequest request = (HttpServletRequest) req;
     String origin = request.getHeader("Origin");
-    if(!allowedOrigin.contains(origin))
+    log.info(origin);
+    if(origin !=null && !allowedOrigin.contains(origin))
       return;
-    response.setHeader("Access-Control-Allow-Origin", origin);
+    response.setHeader("Access-Control-Allow-Origin", origin == null ? ws_host : origin);
     response.setHeader("Access-Control-Allow-Credentials", "true");
     response.setHeader("Access-Control-Allow-Methods",
         "HEAD, GET, POST, PUT, DELETE, PATCH, OPTIONS");


### PR DESCRIPTION
### PR 타입

- [x] 기능 수정

## 작업사항
- corsFilter 수정
    - Origin이 null일 경우(구글 로그인) return하지 않고, 웹서버의 오리진을 response header에 추가하여 반환한다.