### PR TITLE
채팅방 존재 유무 확인 - 상대방의 알람 토큰 추가

### DIFF
--- a/src/main/java/com/windmeal/chat/dto/response/ChatRoomExistsResponse.java
+++ b/src/main/java/com/windmeal/chat/dto/response/ChatRoomExistsResponse.java
@@ -8,8 +8,14 @@ import lombok.NoArgsConstructor;
 @Getter
 public class ChatRoomExistsResponse {
     private final String chatroomId;
+    private final String opponentAlarmToken;
 
-    public ChatRoomExistsResponse(String chatroomId) {
+    public ChatRoomExistsResponse(String chatroomId, String opponentAlarmToken) {
         this.chatroomId = chatroomId;
+        this.opponentAlarmToken = opponentAlarmToken;
+    }
+
+    public static ChatRoomExistsResponse nullInstance() {
+        return new ChatRoomExistsResponse(null, null);
     }
 }

--- a/src/main/java/com/windmeal/chat/service/ChatRoomService.java
+++ b/src/main/java/com/windmeal/chat/service/ChatRoomService.java
@@ -61,7 +61,13 @@ public class ChatRoomService {
     Order order = orderRepository.findById(orderId).orElseThrow(OrderNotFoundException::new);
     ChatroomDocument chatroomDocument =
         chatroomDocumentRepository.findByOrderIdAndGuestId(order.getId(), currentMemberId);
-    return new ChatRoomExistsResponse(chatroomDocument != null ? chatroomDocument.getId() : null);
+    if(chatroomDocument == null) {
+      return ChatRoomExistsResponse.nullInstance();
+    }
+
+    Member owner = memberRepository.findById(
+        order.getOrderer_id()).orElseThrow(MemberNotFoundException::new);
+    return new ChatRoomExistsResponse(chatroomDocument.getId(), owner.getToken());
   }
 
 }


### PR DESCRIPTION
### PR 타입

- [x] 기능 수정

## 작업사항
- 채팅방이 존재할 경우 상대방의 알람 토큰을 추가로 반환
     - 기존 로직에서는 채팅방 생성 과정을 거쳤지만, 수정된 방식에서는 존재하는 채팅방을 반환해주기 때문에 알람토큰을 이 시점에 반환해주어야 함.
